### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SDAutoLayout（一行代码搞定自动布局！）
 
-##众多公司和个人开发者已经使用本库布局：
+## 众多公司和个人开发者已经使用本库布局：
 SDAutoLayout使用者开发的部分app截图 http://www.jianshu.com/p/9bc04d3effb8
 
 一行代码搞定自动布局！致力于做最简单易用的Autolayout库。The most easy way for autolayout.
@@ -9,7 +9,7 @@ SDAutoLayout使用者开发的部分app截图 http://www.jianshu.com/p/9bc04d3ef
 
 497140713（1群）  519489682（2群已满）
 
-##Pod支持：
+## Pod支持：
 
 支持pod：  pod 'SDAutoLayout', '~> 2.1.3'
 
@@ -73,7 +73,7 @@ SDAutoLayout使用者开发的部分app截图 http://www.jianshu.com/p/9bc04d3ef
 
 ## tableview和cell高度自适应：   
 
-####普通（简化）版【推荐使用】：tableview 高度自适应设置只需要2步
+#### 普通（简化）版【推荐使用】：tableview 高度自适应设置只需要2步
     
     1. >> 设置cell高度自适应：
     // cell布局设置好之后调用此方法就可以实现高度自适应（注意：如果用高度自适应则不要再以cell的底边为参照去布局其子view）
@@ -89,7 +89,7 @@ SDAutoLayout使用者开发的部分app截图 http://www.jianshu.com/p/9bc04d3ef
     }
 
 
-####升级版（适应于cell条数少于100的tableview）：tableview 高度自适应设置只需要2步
+#### 升级版（适应于cell条数少于100的tableview）：tableview 高度自适应设置只需要2步
     
     1. >> 设置cell高度自适应：
     // cell布局设置好之后调用此方法就可以实现高度自适应（注意：如果用高度自适应则不要再以cell的底边为参照去布局其子view）


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
